### PR TITLE
README: `ok hand tone 3` -> `tone 3 ok hand`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ Write the word then hit your stroke for emoji to convert:
 -  point up → ☝️
 -  kissing heart → 😘
 -  heart eyes cat → 😻
--  ok hand tone 3 → 👌🏽
+-  tone 3 ok hand → 👌🏽
 
 The plugin can read your recent words to guess which words are the emoji:
 


### PR DESCRIPTION
On my machine, these produce:

* ok hand tone 3: 👌🏽
* tone 3 ok hand: 👌🏽
* okay hand tone 3: okay hand 🏽
* tone 3 okay hand: 👌🏽

The different here is that with `ok hand`, you can put the tone before or after, but with `okay hand`, it must come before. So my recommendation is to change it to before in the documentation so that one doesn't get confused based on which way they spell `ok`/`okay`.